### PR TITLE
Add documentation badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ Asynchronous Twitter API client for Python 3.5+
 .. image:: https://codecov.io/gh/odrling/peony-twitter/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/odrling/peony-twitter
 
+.. image:: https://readthedocs.org/projects/peony-twitter/badge/?version=stable
+  :target: https://peony-twitter.readthedocs.io/en/stable/?badge=stable
+  :alt: Documentation Status
+
 
 
 Installation


### PR DESCRIPTION
It's common enough for project that use badges and have documentation to provide a link to their documentation in the badges. I wondered where your documentation was, finally saw it at the bottom of the README, so, I'd suggest we put it up there.

Now that's done, let's read these docs and see if this lib actually is what I'm looking for :D

Have a nice day ! ✨ 