### PR TITLE
docs: fix 'How to access the API' example (superfluous '.status')

### DIFF
--- a/docs/usage/access.rst
+++ b/docs/usage/access.rst
@@ -16,7 +16,7 @@ So to access
 
 .. code-block:: python
 
-    client.api.status.statuses.home_timeline.get()
+    client.api.statuses.home_timeline.get()
 
 .. _Twitter's documentation: https://dev.twitter.com/rest/reference
 


### PR DESCRIPTION
(This first example on how to access the API appears to have an error and confused me for a while.)